### PR TITLE
🚥 Test and assert images are re-tagged

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,12 @@ on:
 jobs:
   ghcr:
     runs-on: ubuntu-latest
+    # There is no known limit of the number of tags an image in the GitHub
+    # container registry can have, however to avoid any unexpected behaviour
+    # we are creating a new image for each run.
     env:
       TEST_REPOSITORY=${{ github.repository }}-test
       TEST_TAG=${{ github.run_id }}
-      # There is no known limit of the number of tags an image in the GitHub
-      # container registry can have, however to avoid any unexpected behaviour
-      # we are creating a new image for each run.
       TEST_IMAGE=${{ github.repository }}-test:${{ github.run_id }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,10 @@ jobs:
   ghcr:
     runs-on: ubuntu-latest
     env:
-      TEST_REPOSITORY: ghcr.io/${{ github.repository }}-test
-      TEST_IMAGE: ghcr.io/${{ github.repository }}-test:${{ github.run_id }}
+      TEST_REGISTRY: ghcr.io
+      TEST_REPOSITORY: ${{ github.repository }}-test
       TEST_TAG: ${{ github.run_id }}
+      TEST_IMAGE: ghcr.io/${{ github.repository }}-test:${{ github.run_id }}
     steps:
     - uses: actions/checkout@v2
     - name: Login to GitHub Container Registry
@@ -39,7 +40,7 @@ jobs:
       with:
         registry: ghcr.io
         token: ${{ secrets.GHCR_PAT }}
-        repository: ${{ env.TEST_IMAGE }}
+        repository: ${{ env.TEST_REPOSITORY }}
         target: ${{ env.TEST_TAG }}
         tags: |
           multiple-a
@@ -49,7 +50,7 @@ jobs:
         echo "::group::Assertions"
         TAGS=('single' 'multiple-a' 'multiple-b')
         for test_tag in "${TAGS[@]}"
-          image=$TEST_REPOSITORY:$test_tag
+          image=$TEST_REGISTRY/$TEST_REPOSITORY:$test_tag
           if docker manifest inspect $image >/dev/null; then
             echo "::debug::$test_tag found, test passed"
           else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
         do
           IMAGE="${TEST_REGISTRY}/${TEST_REPOSITORY}:${tag}"
           if docker manifest inspect $IMAGE >/dev/null; then
-            echo "$tag found, test passed"
+            echo "pass: $tag found"
           else
             echo "::error::$tag not found, test failed"
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
         do
           IMAGE="${TEST_REGISTRY}/${TEST_REPOSITORY}:${tag}"
           if docker manifest inspect $IMAGE >/dev/null; then
-            echo "::debug::$tag found, test passed"
+            echo "$tag found, test passed"
           else
             echo "::error::$tag not found, test failed"
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - '**'
+  schedule:
+    - cron: '*/37 12 * * *'
 
 jobs:
   ghcr:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         token: ${{ secrets.GHCR_PAT }}
         repository: ${{ env.TEST_REPOSITORY }}
         target: ${{ env.TEST_TAG }}
-        tags: single
+        tags: ${{ github.run_id }}-single
     - name: Add Multiple Tags
       uses: ./
       with:
@@ -43,20 +43,18 @@ jobs:
         repository: ${{ env.TEST_REPOSITORY }}
         target: ${{ env.TEST_TAG }}
         tags: |
-          multiple-a
-          multiple-b
+          ${{ github.run_id }}-multiple-a
+          ${{ github.run_id }}-multiple-b
     - name: Assert Image Has Tags
       run: |
         TAGS=('single' 'multiple-a' 'multiple-b')
         for tag in "${TAGS[@]}"
         do
-          IMAGE="${TEST_REGISTRY}/${TEST_REPOSITORY}:${tag}"
+          IMAGE="${TEST_IMAGE}-${tag}"
           if docker manifest inspect $IMAGE >/dev/null; then
-            echo "pass: $tag found"
+            echo "pass: $IMAGE found"
           else
-            echo "::error::$tag not found, test failed"
+            echo "fail: $IMAGE not found"
+            echo "::error::$IMAGE not found, test failed"
           fi
         done
-    - name: Clean Up Image
-      if: always()
-      run: docker rmi --force $TEST_IMAGE

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       TEST_REPOSITORY: ${{ github.repository }}-test
       TEST_TAG: ${{ github.run_id }}
-      TEST_IMAGE: ${{ github.repository }}-test:${{ github.run_id }}
+      TEST_IMAGE: ghcr.io/${{ github.repository }}-test:${{ github.run_id }}
     steps:
     - uses: actions/checkout@v2
     - name: Login to GitHub Container Registry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
       # each run is testing independently.
     - id: unique
       uses: nanzm/get-time-action@v1.1
+      with:
+        format: 'YYYYMMDDTHHmmssZ'
     - run: |
         docker pull hello-world
         docker tag hello-world $TEST_IMAGE

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     - id: unique
       uses: nanzm/get-time-action@v1.1
       with:
-        format: 'YYYYMMDDTHHmmssZ'
+        format: 'YYYYMMDDTHHmmss'
     - run: |
         docker pull hello-world
         docker tag hello-world $TEST_IMAGE

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,10 @@ on:
 jobs:
   ghcr:
     runs-on: ubuntu-latest
-    # There is no known limit of the number of tags an image in the GitHub
-    # container registry can have, however to avoid any unexpected behaviour
-    # we are creating a new image for each run.
     env:
-      TEST_REPOSITORY: ${{ github.repository }}-test
-      TEST_TAG: ${{ github.run_id }}
+      TEST_REPOSITORY: ghcr.io/${{ github.repository }}-test
       TEST_IMAGE: ghcr.io/${{ github.repository }}-test:${{ github.run_id }}
+      TEST_TAG: ${{ github.run_id }}
     steps:
     - uses: actions/checkout@v2
     - name: Login to GitHub Container Registry
@@ -25,14 +22,6 @@ jobs:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GHCR_PAT }}
-      # A GitHub Action re-run shares the same run ID as the first run. To avoid
-      # a test unintentionally passing due to tags leaking between re-runs, we
-      # generate a unique value here (using the time of the current run) so that
-      # each run is testing independently.
-    - id: unique
-      uses: nanzm/get-time-action@v1.1
-      with:
-        format: 'YYYYMMDDTHHmmss'
     - run: |
         docker pull hello-world
         docker tag hello-world $TEST_IMAGE
@@ -44,7 +33,7 @@ jobs:
         token: ${{ secrets.GHCR_PAT }}
         repository: ${{ env.TEST_REPOSITORY }}
         target: ${{ env.TEST_TAG }}
-        tags: ${{ steps.unique.outputs.time }}-single
+        tags: single
     - name: Add Multiple Tags
       uses: ./
       with:
@@ -53,19 +42,20 @@ jobs:
         repository: ${{ env.TEST_IMAGE }}
         target: ${{ env.TEST_TAG }}
         tags: |
-          ${{ steps.unique.outputs.time }}-multiple-a
-          ${{ steps.unique.outputs.time }}-multiple-b
+          multiple-a
+          multiple-b
     - name: Assert Image Has Tags
-      env:
-        BASE_TAG: ${{ env.TEST_REPOSITORY }}:${{ steps.unique.outputs.time }}
       run: |
         echo "::group::Assertions"
         TAGS=('single' 'multiple-a' 'multiple-b')
         for test_tag in "${TAGS[@]}"
-          image=$BASE_TAG-$test_tag
+          image=$TEST_REPOSITORY:$test_tag
           if docker manifest inspect $image >/dev/null; then
             echo "::debug::$test_tag found, test passed"
           else
             echo "::error::$test_tag not found, test failed"
           fi
         echo "::endgroup::"
+    - name: Clean Up Image
+      if: always()
+      run: docker rmi --force $TEST_IMAGE

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
     # container registry can have, however to avoid any unexpected behaviour
     # we are creating a new image for each run.
     env:
-      TEST_REPOSITORY=${{ github.repository }}-test
-      TEST_TAG=${{ github.run_id }}
-      TEST_IMAGE=${{ github.repository }}-test:${{ github.run_id }}
+      TEST_REPOSITORY: ${{ github.repository }}-test
+      TEST_TAG: ${{ github.run_id }}
+      TEST_IMAGE: ${{ github.repository }}-test:${{ github.run_id }}
     steps:
     - uses: actions/checkout@v2
       # A GitHub Action re-run shares the same run ID as the first run. To avoid

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,12 +49,12 @@ jobs:
       run: |
         echo "::group::Assertions"
         TAGS=('single' 'multiple-a' 'multiple-b')
-        for test_tag in "${TAGS[@]}"
-          image=$TEST_REGISTRY/$TEST_REPOSITORY:$test_tag
-          if docker manifest inspect $image >/dev/null; then
-            echo "::debug::$test_tag found, test passed"
+        for tag in "${TAGS[@]}"
+          IMAGE="${TEST_REGISTRY}/${TEST_REPOSITORY}:${tag}"
+          if docker manifest inspect $IMAGE >/dev/null; then
+            echo "::debug::$tag found, test passed"
           else
-            echo "::error::$test_tag not found, test failed"
+            echo "::error::$tag not found, test failed"
           fi
         echo "::endgroup::"
     - name: Clean Up Image

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,27 +10,54 @@ on:
 jobs:
   ghcr:
     runs-on: ubuntu-latest
+    env:
+      TEST_REPOSITORY=${{ github.repository }}-test
+      TEST_TAG=${{ github.run_id }}
+      # There is no known limit of the number of tags an image in the GitHub
+      # container registry can have, however to avoid any unexpected behaviour
+      # we are creating a new image for each run.
+      TEST_IMAGE=${{ github.repository }}-test:${{ github.run_id }}
     steps:
     - uses: actions/checkout@v2
-    - id: push
-      run: |
-        echo ::set-output name=sha::sha-${GITHUB_SHA:0:7}
+      # A GitHub Action re-run shares the same run ID as the first run. To avoid
+      # a test unintentionally passing due to tags leaking between re-runs, we
+      # generate a unique value here (using the time of the current run) so that
+      # each run is testing independently.
+    - id: unique
+      uses: nanzm/get-time-action@v1.1
+    - run: |
+        docker pull hello-world
+        docker tag hello-world $TEST_IMAGE
+        docker push $TEST_IMAGE
     - name: Add One Tag
       uses: ./
       with:
         registry: ghcr.io
         token: ${{ secrets.GHCR_PAT }}
-        repository: shrink/actions-docker-registry-tag
-        target: sha-8d447bc
-        tags: example-${{ steps.push.outputs.sha }}-a
+        repository: ${{ env.TEST_REPOSITORY }}
+        target: ${{ env.TEST_TAG }}
+        tags: ${{ steps.unique.outputs.time }}-single
     - name: Add Multiple Tags
       uses: ./
       with:
         registry: ghcr.io
         token: ${{ secrets.GHCR_PAT }}
-        repository: shrink/actions-docker-registry-tag
-        target: sha-8d447bc
+        repository: ${{ env.TEST_IMAGE }}
+        target: ${{ env.TEST_TAG }}
         tags: |
-          example-${{ steps.push.outputs.sha }}-b
-          example-${{ steps.push.outputs.sha }}-c
-          latest
+          ${{ steps.unique.outputs.time }}-multiple-a
+          ${{ steps.unique.outputs.time }}-multiple-b
+    - name: Assert Image Has Tags
+      env:
+        BASE_TAG=${{ env.TEST_REPOSITORY }}:${{ steps.unique.outputs.time }}
+      run: |
+        echo "::group::Assertions"
+        TAGS=('single' 'multiple-a' 'multiple-b')
+        for test_tag in "${TAGS[@]}"
+          image=$BASE_TAG-$test_tag
+          if docker manifest inspect $image >/dev/null; then
+            echo "::debug::$test_tag found, test passed"
+          else
+            echo "::error::$test_tag not found, test failed"
+          fi
+        echo "::endgroup::"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,6 @@ jobs:
           multiple-b
     - name: Assert Image Has Tags
       run: |
-        echo "::group::Assertions"
         TAGS=('single' 'multiple-a' 'multiple-b')
         for tag in "${TAGS[@]}"
         do
@@ -58,7 +57,6 @@ jobs:
             echo "::error::$tag not found, test failed"
           fi
         done
-        echo "::endgroup::"
     - name: Clean Up Image
       if: always()
       run: docker rmi --force $TEST_IMAGE

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,12 +50,14 @@ jobs:
         echo "::group::Assertions"
         TAGS=('single' 'multiple-a' 'multiple-b')
         for tag in "${TAGS[@]}"
+        do
           IMAGE="${TEST_REGISTRY}/${TEST_REPOSITORY}:${tag}"
           if docker manifest inspect $IMAGE >/dev/null; then
             echo "::debug::$tag found, test passed"
           else
             echo "::error::$tag not found, test failed"
           fi
+        done
         echo "::endgroup::"
     - name: Clean Up Image
       if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
           ${{ steps.unique.outputs.time }}-multiple-b
     - name: Assert Image Has Tags
       env:
-        BASE_TAG=${{ env.TEST_REPOSITORY }}:${{ steps.unique.outputs.time }}
+        BASE_TAG: ${{ env.TEST_REPOSITORY }}:${{ steps.unique.outputs.time }}
       run: |
         echo "::group::Assertions"
         TAGS=('single' 'multiple-a' 'multiple-b')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,12 @@ jobs:
       TEST_IMAGE: ${{ github.repository }}-test:${{ github.run_id }}
     steps:
     - uses: actions/checkout@v2
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GHCR_PAT }}
       # A GitHub Action re-run shares the same run ID as the first run. To avoid
       # a test unintentionally passing due to tags leaking between re-runs, we
       # generate a unique value here (using the time of the current run) so that


### PR DESCRIPTION
Adds assertions to the tests and schedules the tests to run daily for better visibility into any new issues that might occur with the GitHub Container Registry.