### PR TITLE
fix: Support many image manifest schemas

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -86,6 +86,7 @@ jobs:
   tag-oci-image:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Copy OCI image to repository
         run: |
           token=$(echo -n $token | base64)

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -54,6 +54,21 @@ jobs:
           tags: |
             ${{ env.tag }}-multiple-a
             ${{ env.tag }}-multiple-b
+      - name: Add example OCI image to container registry
+        run: |
+          token=$(echo -n $token | base64)
+          skopeo copy --all \
+          "docker://docker.io/library/hello-world:latest" \
+          "docker://${{ env.image }}-oci" \
+          --dest-registry-token $token \
+          -f oci
+      - name: Add signle tag to OCI image
+        uses: ./
+        with:
+          registry: "${{ env.registry }}"
+          repository: "${{ env.repository }}"
+          target: "${{ env.tag }}-oci"
+          tags: "${{ env.tag }}-oci-single"
   assert-tags-exist:
     runs-on: ubuntu-latest
     needs:
@@ -83,22 +98,3 @@ jobs:
           -H "Authorization: Bearer $token" \
           -H "Accept: application/vnd.$version+json" \
           || (echo "::error::$tag not found" && exit 1)
-  tag-oci-image:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Copy OCI image to repository
-        run: |
-          token=$(echo -n $token | base64)
-          skopeo copy --all \
-          "docker://docker.io/library/hello-world:latest" \
-          "docker://${{ env.image }}-oci" \
-          --dest-registry-token $token \
-          -f oci
-      - name: Add tag to OCI image
-        uses: ./
-        with:
-          registry: "${{ env.registry }}"
-          repository: "${{ env.repository }}"
-          target: "${{ env.tag }}-oci"
-          tags: "${{ env.tag }}-oci-single"

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -73,7 +73,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - tag-example-image
-      - tag-oci-image
     strategy:
       matrix:
         include:

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -58,19 +58,46 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - tag-example-image
+      - tag-oci-image
     strategy:
       matrix:
-        tag:
-          - single
-          - multiple-a
-          - multiple-b
+        include:
+          - tag: single
+            version: "docker.distribution.manifest.v2"
+          - tag: multiple-a
+            version: "docker.distribution.manifest.v2"
+          - tag: multiple-b
+            version: "docker.distribution.manifest.v2"
+          - tag: oci-single
+            version: "oci.image.index.v1"
       fail-fast: false
     env:
       repository: "https://ghcr.io/v2/${{ github.repository }}"
       tag: "test-${{ github.run_id }}-${{ matrix.tag }}"
+      version: "${{ matrix.version }}"
     steps:
       - name: Assert image has tag ${{ matrix.tag }}
         run: |
           token=$(echo -n $token | base64)
-          curl -sf $repository/manifests/$tag -H "Authorization: Bearer $token" \
+          curl -sf $repository/manifests/$tag \
+          -H "Authorization: Bearer $token" \
+          -H "Accept: application/vnd.$version+json" \
           || (echo "::error::$tag not found" && exit 1)
+  tag-oci-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Copy OCI image to repository
+        run: |
+          token=$(echo -n $token | base64)
+          skopeo copy --all \
+          "docker://docker.io/library/hello-world:latest" \
+          "docker://${{ env.image }}-oci" \
+          --dest-registry-token $token \
+          -f oci
+      - name: Add tag to OCI image
+        uses: ./
+        with:
+          registry: "${{ env.registry }}"
+          repository: "${{ env.repository }}"
+          target: "${{ env.tag }}-oci"
+          tags: "${{ env.tag }}-oci-single"


### PR DESCRIPTION
Resolves #17 

Adds support for a OCI and Docker image manifest schemas.

- [x] https://github.com/opencontainers/image-spec/blob/main/media-types.md
- [x] https://docs.docker.com/registry/spec/manifest-v2-1/
- [x] https://docs.docker.com/registry/spec/manifest-v2-2/