### PR TITLE
docs: add 'Permissions' section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ _without_ changing the digest, using Docker Registry API V2.
 :package: [Automatic Release Packaging](#automatic-release-packaging) is used by
 this action, please reference by tag or commit hash in your Workflows.
 
+## Permissions
+
 ## Inputs
 
 Token is an optional input for GitHub's Container Registry. Ensure the Actions


### PR DESCRIPTION
As discussed I'll take a stab at improving the documentation around permissions. This is just a placeholder and reminder for the moment.