### PR TITLE
ci: Clean apt list before installing skopeo

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -57,6 +57,7 @@ jobs:
             ${{ env.tag }}-multiple-b
       - name: Install latest Skopeo # GitHub's ubuntu 22 uses Skopeo 1.4 but we need 1.14
         run: |
+          sudo apt-get clean 
           echo 'deb http://download.opensuse.org/repositories/home:/alvistack/xUbuntu_22.04/ /' | sudo tee /etc/apt/sources.list.d/home:alvistack.list
           curl -fsSL https://download.opensuse.org/repositories/home:alvistack/xUbuntu_22.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home_alvistack.gpg > /dev/null
           sudo apt update

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -57,7 +57,7 @@ jobs:
             ${{ env.tag }}-multiple-b
       - name: Install latest Skopeo # GitHub's ubuntu 22 uses Skopeo 1.4 but we need 1.14
         run: |
-          sudo apt-get clean 
+          sudo apt clean 
           echo 'deb http://download.opensuse.org/repositories/home:/alvistack/xUbuntu_22.04/ /' | sudo tee /etc/apt/sources.list.d/home:alvistack.list
           curl -fsSL https://download.opensuse.org/repositories/home:alvistack/xUbuntu_22.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home_alvistack.gpg > /dev/null
           sudo apt update


### PR DESCRIPTION
There's an error with `mirror.aardsoft.fi`

```
Err:3 http://mirror.aardsoft.fi/opensuse/repositories/home%3A/alvistack/xUbuntu_22.04  skopeo 100:1.14.0-1
  File has unexpected size (8340068 != 8332874). Mirror sync in progress? [IP: 65.21.143.134 80]
  Hashes of expected file:
   - SHA256:572c197377988ca155250c3c32cf83d5c3eb993259eeb4cc2c434e61e2dd1439
   - SHA1:663f246f2328e821ef1d97b09579148e2e88c6f3 [weak]
   - MD5Sum:e2c1994cb38ce7bc3d6ec1095b582795 [weak]
   - Filesize:8332874 [weak]
Fetched 174 kB in 2s (77.0 kB/s)
E: Failed to fetch http://mirror.aardsoft.fi/opensuse/repositories/home%3A/alvistack/xUbuntu_22.04/amd64/skopeo_1.14.0-1_amd64.deb  File has unexpected size (8340068 != 8332874). Mirror sync in progress? [IP: 65.21.143.134 80]
   Hashes of expected file:
    - SHA256:572c197377988ca155250c3c32cf83d5c3eb993259eeb4cc2c434e61e2dd1439
    - SHA1:663f246f2328e821ef1d97b09579148e2e88c6f3 [weak]
    - MD5Sum:e2c1994cb38ce7bc3d6ec1095b582795 [weak]
    - Filesize:8332874 [weak]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```