### PR TITLE
feat: update action runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,26 +1,26 @@
-name: "Docker Registry Tag"
-description: "Add many tags to an image in a Docker Registry (retag, re-tag)"
-author: "Samuel Ryan <sam@samryan.co.uk>"
+name: 'Docker Registry Tag'
+description: 'Add many tags to an image in a Docker Registry (retag, re-tag)'
+author: 'Samuel Ryan <sam@samryan.co.uk>'
 inputs:
   registry:
-    description: "Registry API root domain"
+    description: 'Registry API root domain'
     required: true
   token:
-    description: "Bearer token for the Registry API"
+    description: 'Bearer token for the Registry API'
     required: true
-    default: "${{ github.token }}"
+    default: '${{ github.token }}'
   repository:
-    description: "Image repository name"
+    description: 'Image repository name'
     required: true
   target:
-    description: "Tag of the existing image"
+    description: 'Tag of the existing image'
     required: true
   tags:
-    description: "New-line separated list of new tags"
+    description: 'New-line separated list of new tags'
     required: true
 runs:
-  using: "node20"
-  main: "dist/index.js"
+  using: 'node24'
+  main: 'dist/index.js'
 branding:
-  icon: "tag"
-  color: "blue"
+  icon: 'tag'
+  color: 'blue'


### PR DESCRIPTION
## Summary

- Update `action.yml` runtime from `node20` to `node24`
- Avoids Node.js 20 deprecation warnings on GitHub Actions runners (deprecated Sep 2025, removed Sep 2026)
- See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/